### PR TITLE
Client ip and port parsing

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -244,7 +244,7 @@ def main():
     args = parser.parse_args()
 
     # Start the client and connect to the command-line provided ip address and port
-    # If unspecified, defaults are localhost and port 5000
+    # If unspecified, defaults are localhost and port 5000 
     client = Client(args.ip_address, args.port)
     client.run()
 

--- a/client/client.py
+++ b/client/client.py
@@ -1,3 +1,4 @@
+import argparse
 import imutils
 from imutils.video import VideoStream
 import face_recognition
@@ -29,7 +30,7 @@ class Client():
         self.encoding_data = pickle.loads(open("encodings.pickle", "rb").read())
         self.timeouts = defaultdict(int)
         self.timeout_duration = 60
-        self.location = "/home/pi/imageAnalysisSystem/client"
+        self.location = "/home/lfias-capstone/LFIAS/client"
         self.heartbeat_interval = 10
         self.last_heartbeat = 0
         self.circle_detection_timeout = 5
@@ -237,7 +238,14 @@ class Client():
         return frame # display the image to our screen
 
 def main():
-    client = Client("127.0.0.1", "5000")
+    parser = argparse.ArgumentParser("Client")
+    parser.add_argument("ip_address", nargs="?", help="The ip address of the server that the client will try to connect to", type=str, const="127.0.0.1", default="127.0.0.1")
+    parser.add_argument("port", nargs="?", help="The port of the server that the client will attempt to connect to.", type=str, const="5000", default="5000")
+    args = parser.parse_args()
+
+    # Start the client and connect to the command-line provided ip address and port
+    # If unspecified, defaults are localhost and port 5000
+    client = Client(args.ip_address, args.port)
     client.run()
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ Werkzeug==2.0.3
 WTForms==3.0.1
 cmake
 face_recognition
+picamera


### PR DESCRIPTION
Added argument parsing before starting the client to obtain an ip and port address.  If both are unfilled, it will assume 127.0.0.1 and 5000 by default.  If just one argument is filled in, it assumes it is the ip address and the port will be 5000 by default.  This will allow a bit of a better user experience than manually changing code constants.

Also, picamera was added as a package dependency to requirements.txt as it was throwing an import error upon first time setup on the hardware.  Additional minor fixes were needed, but didn't have anything to do with pip packages and have been documented in the "first time software setup" document.